### PR TITLE
[Add] admin/members_controller

### DIFF
--- a/app/controllers/admin/members_controller.rb
+++ b/app/controllers/admin/members_controller.rb
@@ -13,7 +13,7 @@ class Public::MembersController < ApplicationController
   end
 
   def update
-    @member = User.find(params[:id])
+    @member = Mem.find(params[:id])
     if @member.update(member_params)
       redirect_to members_path, notice:"ユーザー情報を変更しました。"
     else

--- a/app/controllers/admin/members_controller.rb
+++ b/app/controllers/admin/members_controller.rb
@@ -1,14 +1,19 @@
 class Public::MembersController < ApplicationController
+  
+  def index
+    @member = Member.all
+  end
+  
   def show
     @member= Member.find(params[:id])
   end
 
   def edit
-    @member = current_member
+    @member = Member.find(params[:id])
   end
 
   def update
-    @member = current_member
+    @member = User.find(params[:id])
     if @member.update(member_params)
       redirect_to members_path, notice:"ユーザー情報を変更しました。"
     else


### PR DESCRIPTION
current_memberを変更
理由：current_memberですと、admin userのものとなってしまい、他のユーザーのものを見れなくなるため